### PR TITLE
doc(ssh_tunnel): fix config path for docker setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ for example, as follows:
 ```sh
 docker run --rm \
   -u 0:0 \
-  -v "C:/absolute/host/path/to/.ssh":/root/.local/share/omnect-cli \
+  -v "C:/absolute/host/path/to/.ssh":/root/.config/omnect-cli \
   -v dev_env.toml:/dev_env.toml \
   -e CONTAINER_HOST=windows \
   -p 127.0.0.1:4000:4000 \


### PR DESCRIPTION
We changed the base directory for generated ssh configuration files to be consistent in the code base. With this change, the path of the configuration file in the docker example changed, as well. The documentation currently still shows an example with the old path, thus causing the example to not work. We update the example so that it is functional again.